### PR TITLE
add some geometry utilities

### DIFF
--- a/source/include/GeometryUtil.h
+++ b/source/include/GeometryUtil.h
@@ -1,0 +1,32 @@
+#ifndef GEOMETRYUTIL_H
+#define GEOMETRYUTIL_H 1
+
+#include <DDRec/DetectorData.h>
+
+namespace MarlinUtil {
+
+
+  /**
+   * Returns the bfield value in Z direction at (0 0 0),
+   *
+   * Obtains value from Gear (if GEAR File isgiven) or from DD4hep (lcdd) if no
+   * gear file is given.  Throws an exception if neither geometry is
+   * instantiated correctly
+   */
+  double getBzAtOrigin();
+
+
+  /**
+   * Returns DDRec detector extension
+   *
+   * include/excludeFlags must describe unique detector, otherwise exception is thrown
+   * @param includeFlag : bitmask describing detector to select
+   * @param excludeFlag : bitmask describing detector to exclude (optional)
+   *
+   */
+  DD4hep::DDRec::LayeredCalorimeterData const* getLayeredCalorimeterData(unsigned int includeFlag,
+                                                                         unsigned int excludeFlag=0);
+
+}//namespace MarlinUtil
+
+#endif // GEOMETRYUTIL_H

--- a/source/include/GeometryUtil.h
+++ b/source/include/GeometryUtil.h
@@ -9,8 +9,7 @@ namespace MarlinUtil {
   /**
    * Returns the bfield value in Z direction at (0 0 0),
    *
-   * Obtains value from Gear (if GEAR File isgiven) or from DD4hep (lcdd) if no
-   * gear file is given.  Throws an exception if neither geometry is
+   * Obtains value from DD4hep (lcdd) Throws an exception if geometry is not
    * instantiated correctly
    */
   double getBzAtOrigin();

--- a/source/include/HelixClass.h
+++ b/source/include/HelixClass.h
@@ -194,7 +194,7 @@ class HelixClass {
      * Distance[1] - distance along Z axis <br>
      * Distance[2] - 3D distance <br> 
      */
-    float getDistanceToPoint(float * xPoint, float * Distance);
+    float getDistanceToPoint(float const* xPoint, float * Distance);
 
     /**
      * Return distance of the closest approach of the helix to <br>

--- a/source/include/HelixClass_double.h
+++ b/source/include/HelixClass_double.h
@@ -194,7 +194,7 @@ class HelixClass_double {
      * Distance[1] - distance along Z axis <br>
      * Distance[2] - 3D distance <br> 
      */
-    double getDistanceToPoint(double * xPoint, double * Distance);
+    double getDistanceToPoint(double const* xPoint, double * Distance);
 
     /**
      * Return distance of the closest approach of the helix to <br>

--- a/source/src/GeometryUtil.cc
+++ b/source/src/GeometryUtil.cc
@@ -1,0 +1,71 @@
+#include "GeometryUtil.h"
+
+#include <streamlog/streamlog.h>
+
+#include <gear/BField.h>
+#include <gear/GEAR.h>
+#include <marlin/Global.h>
+
+#include <DD4hep/DD4hepUnits.h>
+#include <DD4hep/DetType.h>
+#include <DD4hep/DetectorSelector.h>
+#include <DD4hep/LCDD.h>
+#include <DDRec/DetectorData.h>
+
+
+double MarlinUtil::getBzAtOrigin() {
+
+  double bfield(0.0);
+
+  if( marlin::Global::GEAR != NULL ){
+    try{
+      bfield = marlin::Global::GEAR->getBField().at( gear::Vector3D( 0., 0., 0.) ).z();
+      return bfield;
+    } catch( gear::UnknownParameterException ) {
+    }
+  } else {
+  }
+
+  DD4hep::Geometry::LCDD& lcdd = DD4hep::Geometry::LCDD::getInstance();
+  if ( not lcdd.field().isValid() ) {
+    throw std::runtime_error("LCDD geometry not initialised, cannot get bfield");
+  }
+  const double position[3]={0,0,0}; // position to calculate magnetic field at (the origin in this case)
+  double magneticFieldVector[3]={0,0,0}; // initialise object to hold magnetic field
+  lcdd.field().magneticField(position,magneticFieldVector); // get the magnetic field vector from DD4hep
+  bfield = magneticFieldVector[2]/dd4hep::tesla; // z component at (0,0,0)
+  return bfield;
+
+}
+
+
+DD4hep::DDRec::LayeredCalorimeterData const* MarlinUtil::getLayeredCalorimeterData(unsigned int includeFlag, unsigned int excludeFlag) {
+
+  DD4hep::DDRec::LayeredCalorimeterData * theExtension = 0;
+
+  DD4hep::Geometry::LCDD& lcdd = DD4hep::Geometry::LCDD::getInstance();
+  std::vector<DD4hep::Geometry::DetElement> const& theDetectors = DD4hep::Geometry::DetectorSelector(lcdd).detectors(  includeFlag, excludeFlag ) ;
+
+  if(  theDetectors.size() > 0 ){
+    streamlog_out(DEBUG) << " getLayeredCalorimeterData :  includeFlag: " << DD4hep::DetType( includeFlag )
+                         << " excludeFlag: " << DD4hep::DetType( excludeFlag )
+      //size is > 0 so we can safely use at(0)
+                         << "  found : " << theDetectors.size() << "  - first det: " << theDetectors.at(0).name() << std::endl ;
+  }
+
+  if( theDetectors.size()  != 1 ){
+    std::stringstream es;
+    es << " getLayeredCalorimeterData: selection is not unique (or empty) includeFlag: "
+       << DD4hep::DetType( includeFlag ) << " excludeFlag: " << DD4hep::DetType( excludeFlag )
+       << " --- found detectors : " ;
+    for( unsigned i=0, N= theDetectors.size(); i<N ; ++i ){
+      es << theDetectors.at(i).name() << ", " ;
+    }
+    throw std::runtime_error( es.str() ) ;
+  }
+
+  //size is 1 or we would have exited before, so we can safely use at(0)
+  theExtension = theDetectors.at(0).extension<DD4hep::DDRec::LayeredCalorimeterData>();
+
+  return theExtension;
+}

--- a/source/src/GeometryUtil.cc
+++ b/source/src/GeometryUtil.cc
@@ -2,10 +2,6 @@
 
 #include <streamlog/streamlog.h>
 
-#include <gear/BField.h>
-#include <gear/GEAR.h>
-#include <marlin/Global.h>
-
 #include <DD4hep/DD4hepUnits.h>
 #include <DD4hep/DetType.h>
 #include <DD4hep/DetectorSelector.h>
@@ -16,15 +12,6 @@
 double MarlinUtil::getBzAtOrigin() {
 
   double bfield(0.0);
-
-  if( marlin::Global::GEAR != NULL ){
-    try{
-      bfield = marlin::Global::GEAR->getBField().at( gear::Vector3D( 0., 0., 0.) ).z();
-      return bfield;
-    } catch( gear::UnknownParameterException ) {
-    }
-  } else {
-  }
 
   DD4hep::Geometry::LCDD& lcdd = DD4hep::Geometry::LCDD::getInstance();
   if ( not lcdd.field().isValid() ) {

--- a/source/src/HelixClass.cc
+++ b/source/src/HelixClass.cc
@@ -444,7 +444,7 @@ float HelixClass::getPointInZ(float zLine, float * ref, float * point) {
 
 }
 
-float HelixClass::getDistanceToPoint(float * xPoint, float * Distance) {
+float HelixClass::getDistanceToPoint(float const* xPoint, float * Distance) {
 
   float zOnHelix;
   float phi = atan2(xPoint[1]-_yCentre,xPoint[0]-_xCentre);

--- a/source/src/HelixClass_double.cc
+++ b/source/src/HelixClass_double.cc
@@ -444,7 +444,7 @@ double HelixClass_double::getPointInZ(double zLine, double * ref, double * point
 
 }
 
-double HelixClass_double::getDistanceToPoint(double * xPoint, double * Distance) {
+double HelixClass_double::getDistanceToPoint(double const* xPoint, double * Distance) {
 
   double zOnHelix;
   double phi = atan2(xPoint[1]-_yCentre,xPoint[0]-_xCentre);


### PR DESCRIPTION
Implemented function to get bfield value at 0 0 0 in z direction to be used in different places.
Copied getDetectorExtension function from DDMarlinPandora, because I though I was going to need it, but maybe only later.

Added some const's in helixClass[_double] so I can pass const return values from lcio to those functions

BEGINRELEASENOTES
- Add GeometryUtil file: implemented MarlinUtil::getBFieldInZ and MarlinUtil::getDetectorExtension
  - getBFieldInZ returns bfield at (0 0 0) in z direction in Tesla from GEAR or DD4hep automagically
  - getDetectorExtension returns DDRec detector extension for given flags
- HelixClass[_double]::getDistanceToPoint, first argument is now const to allow passing return values from lcio functions. Fully backward compatible

ENDRELEASENOTES