### PR TITLE
Fixes for some coverity issues

### DIFF
--- a/source/include/ClusterExtended.h
+++ b/source/include/ClusterExtended.h
@@ -63,7 +63,7 @@ class ClusterExtended {
     void setEccentricity( float eccentricity);
     float getEccentricity();
 
-    void setHelix(HelixClass helix);
+    void setHelix(HelixClass const& helix);
     HelixClass & getHelix();
 
     void setHelixChi2R(float helixChi2);

--- a/source/src/ClusterExtended.cc
+++ b/source/src/ClusterExtended.cc
@@ -145,7 +145,7 @@ float ClusterExtended::getEccentricity() {
   return _eccentricity;
 }
 
-void ClusterExtended::setHelix(HelixClass helix) {
+void ClusterExtended::setHelix(HelixClass const& helix) {
   _helix = helix;
   int nHits = int(_hitVector.size());
   float timeMax = -1.0e+20;

--- a/source/src/DDMarlinCED.cc
+++ b/source/src/DDMarlinCED.cc
@@ -300,7 +300,7 @@ void DDMarlinCED::draw( Processor* proc , int waitForKeyboard ) {
             }
             
             signal(SIGWINCH,SIG_IGN);
-            char c = getchar();
+            int c = getchar();
             if(c=='q'||c=='Q'||c==3){ //quit if the user pressed q or strg+c (3 = strg+c)
                 exit(0);
             }

--- a/source/src/DDMarlinCED.cc
+++ b/source/src/DDMarlinCED.cc
@@ -791,6 +791,9 @@ CEDGeoTubeParams PetalParameterConversion (std::vector<DDRec::ZDiskPetalsData::L
   returnParams.delta_z = thicknessSupport; 
   //Again: z0 is the left handed starting point for drawing
   returnParams.z0 = zPosition-returnParams.delta_z;
+
+  returnParams.isBarrel = false;
+
   return returnParams;
 }
 
@@ -821,6 +824,8 @@ CEDGeoTubeParams CalorimeterLayerParameterConversion(std::vector<DDRec::LayeredC
   //cellSize0 is defined to be the middle point of the geometry 
   returnParams.z0 = -cellSize1 + cellSize0;
 
+  returnParams.isBarrel = true;
+
   return returnParams;
 }
 
@@ -850,6 +855,8 @@ CEDGeoTubeParams TPCParameterConversion(FixedPadSizeTPCData *tpc){
   
   returnParams.delta_z = zHalf;
   returnParams.z0 = -zHalf;
+
+  returnParams.isBarrel = true;
 
   return returnParams;
 }

--- a/source/src/DDMarlinCED.cc
+++ b/source/src/DDMarlinCED.cc
@@ -183,6 +183,7 @@ int DDCEDPickingHandler::kbhit(void) {
     //http://stackoverflow.com/questions/448944/c-non-blocking-keyboard-input#448982
     struct timeval tv = { 0L, 0L };
     fd_set fds;
+    FD_ZERO(&fds);
     FD_SET(0, &fds);
     return select(1, &fds, NULL, NULL, &tv);
 }

--- a/source/src/HelixClass.cc
+++ b/source/src/HelixClass.cc
@@ -607,8 +607,8 @@ float HelixClass::getDistanceToHelix(HelixClass * helix, float * pos, float * mo
     ref2[i]=helix->getReferencePoint()[i];
   }
   
-  float pos1[3];
-  float pos2[3];
+  float pos1[6]; //last three accessed in getPointOnCircle
+  float pos2[6]; //last three accessed in getPointOnCircle
   float mom1[3];
   float mom2[3];
 

--- a/source/src/HelixClass_double.cc
+++ b/source/src/HelixClass_double.cc
@@ -607,8 +607,8 @@ double HelixClass_double::getDistanceToHelix(HelixClass_double * helix, double *
     ref2[i]=helix->getReferencePoint()[i];
   }
   
-  double pos1[3];
-  double pos2[3];
+  double pos1[6]; //last three accessed in getPointOnCircle
+  double pos2[6]; //last three accessed in getPointOnCircle
   double mom1[3];
   double mom2[3];
 

--- a/source/src/MarlinUtil.cc
+++ b/source/src/MarlinUtil.cc
@@ -887,6 +887,8 @@ double MarlinUtil::getAbsMomentum(Track* track, double bField) {
 
   const double pAbsReturn = pAbs;
 
+  delete p;
+
   return pAbsReturn;
   
 }


### PR DESCRIPTION
BEGINRELEASENOTES
- MarlinUtil::getAbsMomentum: fix memory leak
- ClusterExtended::setHelix: use const reference instead of object as argument for function
- HelixClass[_double]::getDistanceToHelix: fix out-of-bounds access of array
- DDMarlinCED::*ParameterConversion: initialise isBarrel for CEDGeoTubeParams
- DDMarlinCED:: draw: getchar returns int, value otherwise truncated
- DDMarlinCED::kbhit: initialise fd_set

ENDRELEASENOTES