### PR TITLE
MarlinUtil::getAbsMomentum: use correct delete operator; coverity

### DIFF
--- a/source/src/MarlinUtil.cc
+++ b/source/src/MarlinUtil.cc
@@ -887,7 +887,7 @@ double MarlinUtil::getAbsMomentum(Track* track, double bField) {
 
   const double pAbsReturn = pAbs;
 
-  delete p;
+  delete[] p;
 
   return pAbsReturn;
   


### PR DESCRIPTION

BEGINRELEASENOTES
- MarlinUtil::getAbsMomentum: bugfix: use `delete[]` instead of `delete` as getMomentum uses new[]

ENDRELEASENOTES