### PR TITLE
Geom field validity change

### DIFF
--- a/source/src/GeometryUtil.cc
+++ b/source/src/GeometryUtil.cc
@@ -14,7 +14,7 @@ double MarlinUtil::getBzAtOrigin() {
   double bfield(0.0);
 
   dd4hep::Detector& theDetector = dd4hep::Detector::getInstance();
-  if ( not theDetector.field().isValid() ) {
+  if ( not (theDetector.state() == dd4hep::Detector::READY) ) {
     throw std::runtime_error("Detector geometry not initialised, cannot get bfield");
   }
   const double position[3]={0,0,0}; // position to calculate magnetic field at (the origin in this case)


### PR DESCRIPTION

BEGINRELEASENOTES
- This PR is related to a detector issue discussed in: https://github.com/AIDASoft/DD4hep/issues/356
Given that the return value of det.field().isValid() is always true for design, a different approach on the check of the geometry validity is applied.
- This PR must be integrated with the following PR in AIDASoft/DD4hep: https://github.com/AIDASoft/DD4hep/pull/367

ENDRELEASENOTES