### PR TITLE
MarlinUtilConfig: forward DD4hep dependency

### DIFF
--- a/cmake/MarlinUtilConfig.cmake.in
+++ b/cmake/MarlinUtilConfig.cmake.in
@@ -45,6 +45,7 @@ IF( MarlinUtil_INCLUDE_DIRS )
     LIST( APPEND MarlinUtil_INCLUDE_DIRS ${MarlinUtil_INCLUDE_DIRS}/marlinutil )
 ENDIF( MarlinUtil_INCLUDE_DIRS )
 
+FIND(DD4hep REQUIRED)
 
 # ---------- libraries --------------------------------------------------------
 INCLUDE( "@ILCSOFT_CMAKE_MODULES_ROOT@/MacroCheckPackageLibs.cmake" )


### PR DESCRIPTION
BEGINRELEASENOTES
- MarlinUtilConfig: explicitly add DD4hep dependency so that dependent packages resolve the DD4hep::DDCore etc. libraries

ENDRELEASENOTES