### PR TITLE
Move TrueJet_Parser from MarlinReco to MarlinUtil

### DIFF
--- a/source/include/TrueJet_Parser.h
+++ b/source/include/TrueJet_Parser.h
@@ -1,0 +1,304 @@
+#ifndef TrueJet_Parser_h
+#define TrueJet_Parser_h 1
+
+#include "lcio.h"
+#include <EVENT/LCCollection.h>
+#include <EVENT/MCParticle.h>
+#include <EVENT/ReconstructedParticle.h>
+#include <EVENT/LCRelation.h>
+#include <UTIL/LCRelationNavigator.h>
+#include "IMPL/LCCollectionVec.h"
+#include <IMPL/ReconstructedParticleImpl.h>
+#include <IMPL/ParticleIDImpl.h>
+#include <string>
+
+using namespace lcio ;
+
+struct MCPpyjet : LCIntExtension<MCPpyjet> {};
+struct JetIndex : LCIntExtension<JetIndex> {};
+struct IcnIndex : LCIntExtension<IcnIndex> {};
+struct FcnIndex : LCIntExtension<FcnIndex> {};
+// LCRelationNavigator* reltrue_tj =0;
+
+class TrueJet_Parser {
+
+ public:
+
+
+  TrueJet_Parser()   ;
+  virtual ~TrueJet_Parser() ;
+
+  // These two lines avoid frequent compiler warnings when using -Weffc++
+  TrueJet_Parser( const TrueJet_Parser& ) = delete;
+  TrueJet_Parser& operator=( const TrueJet_Parser& ) = delete;
+
+  virtual    std::string get_recoMCTruthLink(){ return _recoMCTruthLink  ;};
+
+  ReconstructedParticleVec* getJets();       // get all true jets in event
+  ReconstructedParticleVec* getFinalcn();    // get all final colour neutrals in event
+  ReconstructedParticleVec* getInitialcn();  // get all initial colour neutrals in event
+
+  void getall(LCEvent* event)  ;  // Convenient method to get all collections needed: no need to call
+                                  // the three above individually. Also all navigators are set up
+                                  // with this call - See below.
+
+  void delall() ;                 // Tidy up, to be called at end of each event.
+
+  int njets() { return tjcol->getNumberOfElements(); };
+                                  // Get the total number of true jets in the event
+
+  int jetindex(ReconstructedParticle* jet ) { return jet->ext<JetIndex>() ; };
+                                  // Get the index of jet in various arrays. That is, ijet in the
+                                  // methods below.
+
+  const ReconstructedParticle* jet(int ijet) {return jets->at(ijet); }
+                                  // Get the jet object that is jet-number ijet.
+
+  double Eseen(int ijet) { return jets->at(ijet)->getEnergy(); };
+                                  // Seen energy of jet ijet
+
+  double Mseen(int ijet) { return jets->at(ijet)->getMass(); };
+                                  // Seen mass of jet ijet
+
+  const double* pseen(int ijet) { return jets->at(ijet)->getMomentum(); };
+                                  // Seen 3-momentum of jet ijet
+
+  const double* p4seen(int ijet) ;
+                                  // Seen 4-momentum of jet ijet (component 0 is E)
+
+  const ReconstructedParticleVec& seen_partics(int ijet) { return jets->at(ijet)->getParticles(); };
+                                  // Get all PFOs in jet ijet.
+
+  const MCParticleVec& true_partics(int ijet) ;
+                                  // Get all MCPs in jet ijet.
+
+  int type_jet(int ijet) { return jets->at(ijet)->getParticleIDs()[0]->getType() ; };
+                                  // Get the type jet ijet: 1 = hadronic, from string
+                                  //                        2 = leptonic
+                                  //                        3 = hadronic, from cluster
+                                  //                        4 = ISR
+                                  //                        5 = overlay
+                                  //                        6 = M.E. photon
+                                  // If the jet is completely unseen, the type is negated.
+                                  // If the jet originates from a gluon-splitting, the type is
+                                  // modified to type + (jet# radiating the gluon)*100
+
+  double Etrue(int ijet) ;
+                                  // True energy of jet ijet
+
+  double Mtrue(int ijet) ;
+                                  // True mass of jet ijet
+
+  const double* ptrue(int ijet) ;
+                                  // True 3-momentum of jet ijet
+
+  const double* p4true(int ijet) ;
+                                  // True 4-momentum of jet ijet (component 0 is E)
+
+  double Equark(int ijet) {return ( final_elementon(ijet) != NULL ? final_elementon(ijet)->getEnergy() : 0.);};
+                                  // Energy of the last quark/lepton before "hadronisation" jet ijet
+
+  double Mquark(int ijet) {return ( final_elementon(ijet) != NULL ? final_elementon(ijet)->getMass() : 0 );};
+                                 // Mass of the last quark/lepton before "hadronisation" jet ijet
+
+  const double* pquark(int ijet);
+                                 // 3-momentum of the last quark/lepton before "hadronisation" jet ijet
+
+  const double* p4quark(int ijet) ;
+                                 // 4-momentum of the last quark/lepton before "hadronisation" jet ijet
+
+  double Etrueseen(int ijet) ;
+                                  // Sum of true energy of all the particles of jet ijet, that were detected
+
+  double Mtrueseen(int ijet) ;
+                                  // Sum of true mass of all the particles of jet ijet, that were detected
+
+  const double* ptrueseen(int ijet) ;
+                                  // Sum of true 3-momentum of all the particles of jet ijet, that were detected
+
+  const double* p4trueseen(int ijet) ;
+                                  // Sum of true 4-momentum of all the particles of jet ijet, that were detected
+                                  // (component 0 is E)
+
+  const IntVec& final_siblings( int ijet );
+                                  // list of jets grouped with jet ijet at the end of the parton-shower
+
+  const IntVec& initial_siblings( int ijet );
+                                  // list of jets grouped with jet ijet seen from the  beginning of the parton-shower
+                                  // (i.e. those that, together with jet ijet, belong to the same initial colour neutral)
+
+  int mcpjet( MCParticle* mcp);
+  int mcpicn( MCParticle* mcp);
+  int mcpfcn( MCParticle* mcp);
+                                  // Get jetnumber, initial or final colour neutral of true particle
+                                  // mcp
+
+  int recojet( ReconstructedParticle* reco);
+  int recoicn( ReconstructedParticle* reco);
+  int recofcn( ReconstructedParticle* reco);
+                                  // Get jetnumber, initial or final colour neutral of reconstructed
+                                  // particle reco.
+
+
+  int final_cn( int ijet );
+                                  // the id of the final colour-neutral that jet ijet comes form
+
+  int initial_cn( int ijet );
+                                  // the id of the initial colour-neutral that jet ijet comes form
+
+  const IntVec& jets_of_final_cn( int ifcn );
+                                  // the list of the jets final colour-neutral ifcn gives rise to
+
+  const IntVec& jets_of_initial_cn( int iicn );
+                                  // the list of the jets initial colour-neutral iicn gives rise to
+
+  int nicn() { return icncol->getNumberOfElements(); };
+                                  // Number of initial colour neutrals
+
+  int type_icn_parent(int iicn) { return initialcns->at(iicn)->getParticleIDs()[0]->getType() ; };
+                                 // type of initial colour neutral iicn:  1 or 3 : c.n. is a quark pair
+                                 //                                            2 : c.n. is a lepton pair
+                                 //                                            4 : c.n. is an ISR
+                                 //                                            6 : c.n. is a ME photon
+
+
+  const IntVec& type_icn_comps(int iicn) ;
+                                 // types of each of the quarks/leptons constituting this
+                                 // initial colour neutral = type of the corresponding jet
+
+  int pdg_icn_parent(int iicn) { return initialcns->at(iicn)->getParticleIDs()[0]->getPDG() ; };
+                                 // PDG of parent of initial colour neutral iicn, i.e. the boson (23=Z, 24=W, 25=H ...)
+
+  const IntVec& pdg_icn_comps(int iicn) ;
+                                 // PDGs of each of the quarks/leptons constituting this
+                                 // initial colour neutral
+
+  double E_icn(int iicn) { return initialcns->at(iicn)->getEnergy();};
+                                 // Energy of initial colour neutral iicn.
+
+  double M_icn(int iicn) {; return initialcns->at(iicn)->getMass();};
+                                 // Mass of initial colour neutral iicn.
+
+  const double* p_icn(int iicn){ return initialcns->at(iicn)->getMomentum();} ;
+                                 // 3-momentum of initial colour neutral iicn.
+
+  const double* p4_icn(int iicn) ;
+                                 // 4-momentum  of initial colour neutral iicn (component 0 is E).
+
+  int nfcn() { return fcncol->getNumberOfElements(); };
+                                  // Number of final colour neutrals
+
+  int type_fcn_parent(int ifcn) { return finalcns->at(ifcn)->getParticleIDs()[0]->getType() ; };
+                                 // type of parent of final colour neutral ifcn. Same as that of the
+                                 // two jets constituting the c.n. (bare type, i.e. always positive,
+                                 // no gluon-splitting indication)
+
+  const IntVec& type_fcn_comps(int ifcn) ;
+                                 // types of the quarks/leptons constituting this final colour neutral.
+                                 // Equal to the type of the corresponding jet.
+
+  int pdg_fcn_parent(int ifcn) { return finalcns->at(ifcn)->getParticleIDs()[0]->getPDG() ; };
+                                 // PDG of parent of final colour neutral ifcn:  (92=string, 91=cluster,
+                                 // 22=photon (ISR or ME), any lepton PDG=lepton pair)
+
+  const IntVec& pdg_fcn_comps(int ifcn) ;
+                                 // PDGs of the quarks/leptons constituting this final colour neutral
+
+  double E_fcn(int ifcn){return finalcns->at(ifcn)->getEnergy(); } ;
+                                 // Energy of final colour neutral ifcn.
+
+  double M_fcn(int ifcn){return finalcns->at(ifcn)->getMass();} ;
+                                 // Mass of final colour neutral ifcn.
+
+  const double* p_fcn(int ifcn){return finalcns->at(ifcn)->getMomentum(); } ;
+                                 // 3-momentum of final colour neutral ifcn.
+
+  const double* p4_fcn(int ifcn) ;
+                                 // 4-momentum  of final colour neutral ifcn (component 0 is E).
+
+  MCParticle* initial_elementon(int ijet) ;
+                                 // The MCParticle that is at the beginning of the parton shower
+                                 // leading to jet ijet
+
+  MCParticle* final_elementon(int ijet) ;
+                                 // The MCParticle that is at the end of the parton shower
+                                 // leading to jet ijet
+
+  const MCParticleVec& elementons_final_cn(int ifcn) ;
+                                 // list of MCParticles constituting the final colour neutral
+
+  const MCParticleVec& elementons_initial_cn(int ifcn) ;
+                                 // list of MCParticles constituting the initial colour neutral
+
+                                 // All the following navigators are set up by a call to getall ...
+                                 // Note that most, if not all, information one can get using
+                                 // these navigators can already be obtained in a simpler way using
+                                 // the method above!
+
+                                 // We list what they connect like so:
+                                 // "a xxx -> yyys" means that navigator relzzz gives
+                                 //
+                                 // yyyvec = relzzz->getRelated T o Objects( a xxx ) ,
+                                 //
+                                 // and, consequently, that the relation in the other direction is gotten by
+                                 //
+                                 // xxxvec = relzzz->getRelated F r o m Objects( a yyy )
+                                 //
+                                 // In [] the LCIO type of the vector-elements are given. a truejet is a
+                                 // ReconstructedParticle, and  jets->at(ijet) gives the truejet object
+                                 // at index ijet (i.e. the identifier used in all the other methods),
+                                 // while in the other way jetindex( truejet-object ) gives the index.
+
+
+    LCRelationNavigator* relfcn{};      // a truejet to final colour neutral(s)    [ ReconstructedParticle:s ]
+    LCRelationNavigator* relicn{};      // a truejet to initial colour neutral(s)   [ ReconstructedParticle:s ]
+
+    LCRelationNavigator* relfp{};       // a truejet to its final quarks/leptons   [ MCParticle:s ]
+    LCRelationNavigator* relip{};       // a truejet to its initial quarks/leptons [ MCParticle:s ]
+
+
+    LCRelationNavigator* reltjreco{};   // a truejet to all seen particles in it    [ ReconstructedParticle:s ]
+    LCRelationNavigator* reltjmcp{};    // a truejet to all true particles in it   [ MCParticle:s ]
+
+
+                                 // Example:
+
+//       ReconstructedParticle* pfo = dynamic_cast<ReconstructedParticle*>( pfocol->getElementAt( j ) ) ;
+//       LCObjectVec jetvec = reltjreco->getRelatedFromObjects( pfo );
+//       int ijet = jetindex( dynamic_cast<ReconstructedParticle*>(jetvec[0]));
+
+                                // will give you the jetnumber (ijet) that PFO j belongs to
+                                // (Note that there is a method above for the opposite operation:
+                                //  seen_partics(ijet) returns a ReconstructedParticlVec of all
+                                //  PFOs belonging to jet ijet)
+
+    LCRelationNavigator* reltrue_tj{};  // = RecoMCTruthLink
+
+    LCCollection* tjcol{};
+    LCCollection* fcncol{};
+    LCCollection* icncol{};
+    ReconstructedParticleVec* jets{};
+    ReconstructedParticleVec* finalcns{};
+    ReconstructedParticleVec* initialcns{};
+
+ protected:
+ /**  input collection names */
+  std::string _trueJetCollectionName{};
+  std::string _finalColourNeutralCollectionName{};
+  std::string _initialColourNeutralCollectionName{};
+  std::string _trueJetPFOLink{};
+  std::string _trueJetMCParticleLink{};
+  std::string _finalElementonLink{};
+  std::string _initialElementonLink{};
+  std::string _finalColourNeutralLink{};
+  std::string _initialColourNeutralLink{};
+  std::string _recoMCTruthLink{};
+  int _COUNT_FSR{};
+private:
+  LCEvent* evt{};
+  double p4[4]{};
+  double p3[3]{};
+  IntVec* intvec{};
+  MCParticleVec* mcpartvec{};
+} ;
+#endif

--- a/source/src/TrueJet_Parser.cc
+++ b/source/src/TrueJet_Parser.cc
@@ -1,0 +1,670 @@
+#include "TrueJet_Parser.h"
+#include <stdlib.h>
+#include <math.h>
+//#include <cmath>
+#include <iostream>
+#include <iomanip>
+
+
+// ----- include for verbosity dependend logging ---------
+#include "marlin/VerbosityLevels.h"
+
+#ifdef MARLIN_USE_AIDA
+#include <marlin/AIDAProcessor.h>
+#include <AIDA/IHistogramFactory.h>
+#include <AIDA/ICloud1D.h>
+//#include <AIDA/IHistogram1D.h>
+#endif // MARLIN_USE_AIDA
+
+
+using namespace lcio ;
+using namespace marlin ;
+
+struct MCPseen : LCIntExtension<MCPseen> {} ;
+
+
+  TrueJet_Parser::TrueJet_Parser() {
+
+    intvec=new IntVec()    ;
+    mcpartvec=new MCParticleVec()    ;
+    _COUNT_FSR=1;
+}
+
+TrueJet_Parser::~TrueJet_Parser() {
+}
+
+
+
+//*************************///
+const double* TrueJet_Parser::p4seen(int ijet) {
+  p4[0]=Eseen(ijet);
+  const double* mom = pseen(ijet);
+   for (int kk=1 ; kk<=3 ; kk++ ) {
+     p4[kk]=mom[kk-1];
+   }
+   return p4 ;
+}
+
+
+double TrueJet_Parser::Etrue(int ijet) {
+  static FloatVec www ;
+  LCObjectVec mcpvec = reltjmcp->getRelatedToObjects( jets->at(ijet) );
+  www = reltjmcp->getRelatedToWeights( jets->at(ijet));
+  double E=0.0;
+  for ( unsigned kk=0 ; kk<mcpvec.size() ; kk++ ) {
+    MCParticle* mcp  = dynamic_cast<MCParticle*>(mcpvec[kk]);
+    if ( _COUNT_FSR ) {
+      if (  abs(www[kk]) == 1.0) {
+        E+=mcp->getEnergy();
+      }
+    } else {
+      if (  www[kk] == 1.0) {
+        E+=mcp->getEnergy();
+      }
+    }
+  }
+  return E;
+}
+double TrueJet_Parser::Mtrue(int ijet) {
+  const double* p_4 = p4true(ijet);
+  double psqr=0;
+  for (int kk=1 ; kk<=3 ; kk++ ) {
+     psqr+=p_4[kk]*p_4[kk];
+  }
+  double M=sqrt(p_4[0]*p_4[0]-psqr);
+  return M ;
+}
+const double* TrueJet_Parser::ptrue(int ijet) {
+  static FloatVec www ;
+  LCObjectVec mcpvec = reltjmcp->getRelatedToObjects( jets->at(ijet) );
+  www =  reltjmcp->getRelatedToWeights( jets->at(ijet));
+  p3[0]=0.; p3[1]=0.; p3[2]=0.;
+  for ( unsigned kk=0 ; kk<mcpvec.size() ; kk++ ) {
+    MCParticle* mcp  = dynamic_cast<MCParticle*>(mcpvec[kk]);
+    if ( _COUNT_FSR ) {
+      if (  abs(www[kk]) == 1.0) {
+        const double* mom = mcp->getMomentum();
+        for (int jj=0 ; jj<3 ; jj++ ) {
+          p3[jj]+=mom[jj];
+        }
+      }
+    } else {
+      if (  www[kk] == 1.0) {
+        const double* mom = mcp->getMomentum();
+        for (int jj=0 ; jj<3 ; jj++ ) {
+          p3[jj]+=mom[jj];
+        }
+      }
+    }
+  }
+  return p3;
+}
+
+const double* TrueJet_Parser::p4true(int ijet) {
+  const double* mom = ptrue(ijet);
+  for (int kk=1 ; kk<=3 ; kk++ ) {
+     p4[kk]=mom[kk-1];
+  }
+  p4[0]=Etrue(ijet);
+  return p4 ;
+}
+
+const MCParticleVec& TrueJet_Parser::true_partics(int ijet) {
+  mcpartvec->clear();
+  MCParticleVec* jetmcps=mcpartvec;
+  LCObjectVec jetmcpsx = reltjmcp->getRelatedToObjects( jets->at(ijet) );
+  for ( unsigned iii=0 ; iii < jetmcpsx.size() ; iii++ ) {
+    jetmcps->push_back(dynamic_cast<MCParticle*>(jetmcpsx[iii]));
+  }
+  return *jetmcps;
+}
+
+const double* TrueJet_Parser::pquark(int ijet) {
+  if (final_elementon(ijet) != NULL ) {
+    return final_elementon(ijet)->getMomentum() ;
+  } else {
+    p3[0]=0. ;p3[1]=0. ;p3[2]=0. ;
+    return p3 ;
+  }
+}
+
+const double* TrueJet_Parser::p4quark(int ijet) {
+  const double* mom = pquark(ijet);
+  for (int kk=1 ; kk<=3 ; kk++ ) {
+     p4[kk]=mom[kk-1];
+  }
+  p4[0]=Equark(ijet);
+  return p4 ;
+}
+
+
+double TrueJet_Parser::Etrueseen(int ijet) {
+  if (  reltrue_tj == 0 ) {
+    LCCollection* rmclcol = NULL;
+    try{
+     rmclcol = evt->getCollection( get_recoMCTruthLink() );
+    }
+    catch( lcio::DataNotAvailableException e )
+    {
+      streamlog_out(WARNING) << get_recoMCTruthLink()   << " collection not available" << std::endl;
+        rmclcol = NULL;
+    }
+    reltrue_tj = new LCRelationNavigator( rmclcol );
+  }
+  LCObjectVec mcpvec = reltjmcp->getRelatedToObjects( jets->at(ijet) );
+  double E=0.0;
+  for ( unsigned kk=0 ; kk<mcpvec.size() ; kk++ ) {
+    MCParticle* mcp  = dynamic_cast<MCParticle*>(mcpvec[kk]);
+    LCObjectVec recovec = reltrue_tj->getRelatedFromObjects( mcp);
+    if ( recovec.size() > 0 ) { // if reconstructed
+      if ( mcp->getParents().size() == 0 || ! ( mcp->getParents()[0]->ext<MCPseen>() == 1) ) {  // if ancestor not already counted
+        E+=mcp->getEnergy();
+      }
+      mcp->ext<MCPseen>() = 1 ;
+    } else {
+      if (  mcp->getParents().size() > 0 && mcp->getParents()[0]->ext<MCPseen>() == 1 ) {   // if parent of particles seen,
+                                                                                            // consider the particle itself as seen as seen
+        mcp->ext<MCPseen>() = 1 ;
+      }
+    }
+  }
+  return E;
+}
+double TrueJet_Parser::Mtrueseen(int ijet) {
+  const double* p_4 = p4trueseen(ijet);
+  double psqr=0;
+  for (int kk=1 ; kk<=3 ; kk++ ) {
+     psqr+=p_4[kk]*p_4[kk];
+  }
+  double M=sqrt(p_4[0]*p_4[0]-psqr);
+  return M ;
+}
+const double* TrueJet_Parser::ptrueseen(int ijet) {
+  if (  reltrue_tj == 0 ) {
+    LCCollection* rmclcol = NULL;
+     try{
+      rmclcol = evt->getCollection( get_recoMCTruthLink() );
+    }
+    catch( lcio::DataNotAvailableException e )
+    {
+      streamlog_out(WARNING) << get_recoMCTruthLink()   << " collection not available" << std::endl;
+        rmclcol = NULL;
+    }
+    reltrue_tj = new LCRelationNavigator( rmclcol );
+  }
+  LCObjectVec mcpvec = reltjmcp->getRelatedToObjects( jets->at(ijet) );
+  p3[0]=0 ; p3[1]=0 ; p3[2]=0 ;
+  for ( unsigned kk=0 ; kk<mcpvec.size() ; kk++ ) {
+    MCParticle* mcp  = dynamic_cast<MCParticle*>(mcpvec[kk]);
+    LCObjectVec recovec = reltrue_tj->getRelatedFromObjects( mcp);
+    if ( recovec.size() > 0 ) { // if reconstructed
+      if ( mcp->getParents().size() == 0 || ! ( mcp->getParents()[0]->ext<MCPseen>() == 1 ) ) {  // if ancestor not already counted
+        const double* mom = mcp->getMomentum();
+        for (int jj=0 ; jj<3 ; jj++ ) {
+          p3[jj]+=mom[jj];
+        }
+      }
+      mcp->ext<MCPseen>() = 1 ;
+    } else {
+      if (  mcp->getParents().size() > 0 && mcp->getParents()[0]->ext<MCPseen>() == 1 ) {   // if parent of particles seen,
+                                                                                            // consider the particle itself as seen as seen
+        mcp->ext<MCPseen>() = 1 ;
+      }
+    }
+  }
+  return p3;
+}
+
+const double* TrueJet_Parser::p4trueseen(int ijet) {
+  const double* mom = ptrueseen(ijet);
+  for (int kk=1 ; kk<=3 ; kk++ ) {
+     p4[kk]=mom[kk-1];
+  }
+  p4[0]=Etrueseen(ijet);
+  return p4 ;
+}
+
+
+ReconstructedParticleVec* TrueJet_Parser::getJets(){
+  //LCObjectVec* TrueJet_Parser::jets(){
+
+
+
+    ReconstructedParticleVec* tjs = new ReconstructedParticleVec();
+    //    LCObjectVec* tjs = new LCObjectVec();
+    int ntj = tjcol->getNumberOfElements()  ;
+    // std::cout << " n jets " << ntj << std::endl;
+
+    for(int j=0; j< ntj ; j++){
+
+      ReconstructedParticle* tj = dynamic_cast<ReconstructedParticle*>( tjcol->getElementAt( j ) ) ;
+      tjs->push_back(tj);
+      tj->ext<JetIndex>()=j;
+
+
+    }
+    return tjs;
+}
+
+ ReconstructedParticleVec* TrueJet_Parser::getFinalcn(){
+
+
+    ReconstructedParticleVec* fcns = new  ReconstructedParticleVec();
+    int nfcn = fcncol->getNumberOfElements()  ;
+    //std::cout << " n fcn " << nfcn << std::endl;
+
+    for(int j=0; j< nfcn ; j++){
+
+      ReconstructedParticle* fcn = dynamic_cast<ReconstructedParticle*>( fcncol->getElementAt( j ) ) ;
+      fcns->push_back(fcn);
+      fcn->ext<FcnIndex>()=j;
+    }
+    return fcns;
+}
+ ReconstructedParticleVec* TrueJet_Parser::getInitialcn(){
+
+
+    ReconstructedParticleVec* icns = new  ReconstructedParticleVec();
+    int nicn = icncol->getNumberOfElements()  ;
+    //std::cout << " n icn " << nicn << std::endl;
+
+    for(int j=0; j< nicn ; j++){
+
+      ReconstructedParticle* icn = dynamic_cast<ReconstructedParticle*>( icncol->getElementAt( j ) ) ;
+      icns->push_back(icn);
+      icn->ext<IcnIndex>()=j;
+    }
+    return icns;
+}
+const IntVec&  TrueJet_Parser::final_siblings( int ijet ) {
+  intvec->clear();
+  IntVec* sibl=intvec;
+  LCObjectVec fcnvec = relfcn->getRelatedToObjects( jets->at(ijet) );
+  int nsibl=0;
+  for ( unsigned kk=0 ; kk<fcnvec.size() ; kk++ ) {
+    ReconstructedParticleVec jetvec= dynamic_cast<ReconstructedParticle*>(fcnvec[kk])->getParticles();
+    for ( unsigned jj=0 ; jj<jetvec.size() ; jj++ ) {
+      if ( jetvec[jj] != jets->at(ijet) ) {
+        // sibling
+        int jjet=jetvec[jj]->ext<JetIndex>();
+        sibl->push_back(jjet);
+        nsibl++;
+      }
+    }
+  }
+  return *sibl;
+  //
+
+}
+const IntVec& TrueJet_Parser::initial_siblings( int ijet ){
+  intvec->clear();
+  IntVec* sibl=intvec;
+  LCObjectVec icnvec = relicn->getRelatedToObjects( jets->at(ijet) );
+  int nsibl=0;
+  for ( unsigned kk=0 ; kk<icnvec.size() ; kk++ ) {
+    ReconstructedParticleVec jetvec= dynamic_cast<ReconstructedParticle*>(icnvec[kk])->getParticles();
+    for ( unsigned jj=0 ; jj<jetvec.size() ; jj++ ) {
+      if ( jetvec[jj] != jets->at(ijet) ) {
+        int jjet=jetvec[jj]->ext<JetIndex>();
+        sibl->push_back(jjet);
+        nsibl++;
+      }
+    }
+  }
+  return *sibl;
+  //
+
+}
+
+int TrueJet_Parser::mcpjet( MCParticle* mcp) {
+   LCObjectVec jetvec = reltjmcp->getRelatedFromObjects( mcp );
+   if (jetvec.size() > 0 ) {
+     return  jetindex( dynamic_cast<ReconstructedParticle*>(jetvec[0])) ;
+   } else {
+     return -1000 ;
+   }
+}
+
+int TrueJet_Parser::mcpicn( MCParticle* mcp) {
+   LCObjectVec jetvec = reltjmcp->getRelatedFromObjects( mcp );
+   if (jetvec.size() > 0 ) {
+     return  final_cn(jetindex( dynamic_cast<ReconstructedParticle*>(jetvec[0]))) ;
+   } else {
+     return -1000 ;
+   }
+
+}
+
+int TrueJet_Parser::mcpfcn( MCParticle* mcp) {
+   LCObjectVec jetvec = reltjmcp->getRelatedFromObjects( mcp );
+   if (jetvec.size() > 0 ) {
+     return initial_cn( jetindex( dynamic_cast<ReconstructedParticle*>(jetvec[0]))) ;
+   } else {
+     return -1000 ;
+   }
+
+}
+
+int TrueJet_Parser::recojet( ReconstructedParticle* reco) {
+   LCObjectVec jetvec = reltjreco->getRelatedFromObjects( reco );
+   if (jetvec.size() > 0 ) {
+     return  jetindex( dynamic_cast<ReconstructedParticle*>(jetvec[0])) ;
+   } else {
+     return -1000 ;
+   }
+
+}
+
+int TrueJet_Parser::recoicn( ReconstructedParticle* reco) {
+   LCObjectVec jetvec = reltjreco->getRelatedFromObjects( reco );
+   if (jetvec.size() > 0 ) {
+     return  final_cn(jetindex( dynamic_cast<ReconstructedParticle*>(jetvec[0]))) ;
+   } else {
+     return -1000 ;
+   }
+
+}
+
+int TrueJet_Parser::recofcn( ReconstructedParticle* reco) {
+   LCObjectVec jetvec = reltjreco->getRelatedFromObjects( reco );
+   if (jetvec.size() > 0 ) {
+     return initial_cn( jetindex( dynamic_cast<ReconstructedParticle*>(jetvec[0]))) ;
+   } else {
+     return -1000 ;
+   }
+
+}
+
+int TrueJet_Parser::final_cn( int ijet ) {
+   LCObjectVec fcnvec = relfcn->getRelatedToObjects( jets->at(ijet) );
+   int fcn ;
+   if (fcnvec.size() > 0 ) {
+     fcn=fcnvec[0]->ext<FcnIndex>();
+   } else {
+     fcn = -1 ;
+   }
+   return fcn;
+}
+int TrueJet_Parser::initial_cn( int ijet ) {
+   LCObjectVec icnvec = relicn->getRelatedToObjects( jets->at(ijet) );
+   int icn ;
+   if (icnvec.size() > 0 ) {
+      icn=icnvec[0]->ext<IcnIndex>();
+   } else {
+     icn = -1 ;
+   }
+
+   return icn;
+}
+
+const IntVec&  TrueJet_Parser::jets_of_final_cn( int ifcn ) {
+  intvec->clear();
+  IntVec* jets_of_fcn=intvec;
+  // way to find: jet-to-icn link icn->reco : jets, find notthis.
+  //  index<->jet : LCExtension
+  LCObjectVec jetvec = relfcn->getRelatedFromObjects(  finalcns->at(ifcn) );
+    // ReconstructedParticleVec jetvec= dynamic_cast<ReconstructedParticle*>(fcnvec[ifcn])->getParticles();
+  for ( unsigned kk=0 ; kk<jetvec.size() ; kk++ ) {
+    int jjet=jetvec[kk]->ext<JetIndex>();
+    jets_of_fcn->push_back(jjet);
+  }
+  return *jets_of_fcn;
+  //
+
+}
+const IntVec&  TrueJet_Parser::jets_of_initial_cn( int iicn ) {
+  intvec->clear();
+  IntVec* jets_of_icn=intvec;
+  // way to find: jet-to-icn link icn->reco : jets, find notthis.
+  //  index<->jet : LCExtension
+  //LCObjectVec jetvec = relfcn->getRelatedFromObjects(  finalcns->at(ifcn) );
+  ReconstructedParticleVec jetvec= dynamic_cast<ReconstructedParticle*>(initialcns->at(iicn))->getParticles();
+  for ( unsigned kk=0 ; kk<jetvec.size() ; kk++ ) {
+    int jjet=jetvec[kk]->ext<JetIndex>();
+    jets_of_icn->push_back(jjet);
+  }
+  return *jets_of_icn;
+  //
+
+}
+
+const IntVec&  TrueJet_Parser::pdg_icn_comps(int iicn) {
+  intvec->clear();
+  for ( unsigned ipid=1 ; ipid <  initialcns->at(iicn)->getParticleIDs().size() ; ipid++ ) {
+    intvec->push_back( initialcns->at(iicn)->getParticleIDs()[ipid]->getPDG());
+  }
+  return *intvec;
+  //
+
+}
+
+const IntVec&  TrueJet_Parser::type_icn_comps(int iicn) {
+  intvec->clear();
+  for ( unsigned ipid=1 ; ipid <  initialcns->at(iicn)->getParticleIDs().size() ; ipid++ ) {
+    intvec->push_back( initialcns->at(iicn)->getParticleIDs()[ipid]->getType());
+  }
+  return *intvec;
+  //
+
+}
+
+
+const double* TrueJet_Parser::p4_icn(int iicn) {
+  const double* mom = p_icn(iicn);
+   for (int kk=1 ; kk<=3 ; kk++ ) {
+     p4[kk]=mom[kk-1];
+   }
+   p4[0]=E_icn(iicn);
+   return p4 ;
+}
+
+const IntVec&  TrueJet_Parser::pdg_fcn_comps(int ifcn) {
+  intvec->clear();
+  for ( unsigned ipid=1 ; ipid <  finalcns->at(ifcn)->getParticleIDs().size() ; ipid++ ) {
+    intvec->push_back( finalcns->at(ifcn)->getParticleIDs()[ipid]->getPDG());
+  }
+  return *intvec;
+  //
+
+}
+const IntVec&  TrueJet_Parser::type_fcn_comps(int ifcn) {
+  intvec->clear();
+  for ( unsigned ipid=1 ; ipid <  finalcns->at(ifcn)->getParticleIDs().size() ; ipid++ ) {
+    intvec->push_back( finalcns->at(ifcn)->getParticleIDs()[ipid]->getType());
+  }
+  return *intvec;
+  //
+
+}
+
+
+
+const double* TrueJet_Parser::p4_fcn(int ifcn) {
+  const double* mom = p_fcn(ifcn);
+   for (int kk=1 ; kk<=3 ; kk++ ) {
+     p4[kk]=mom[kk-1];
+   }
+   p4[0]=E_fcn(ifcn);
+   return p4 ;
+}
+
+MCParticle* TrueJet_Parser::initial_elementon(int ijet){
+//  int icn=initial_cn(ijet);
+//  LCObjectVec elementonvec = relip->getRelatedToObjects(initialcns->at(icn));
+  LCObjectVec elementonvec = relip->getRelatedToObjects(jets->at(ijet));
+  if (elementonvec.size() > 0 ) {
+    MCParticle* mcp  = dynamic_cast<MCParticle*>(elementonvec[0]);
+    return mcp;
+  } else {
+    return NULL;
+  }
+
+}
+MCParticle* TrueJet_Parser::final_elementon(int ijet){
+//  int fcn=final_cn(ijet);
+//  LCObjectVec elementonvec = relfp->getRelatedToObjects(finalcns->at(fcn));
+  LCObjectVec elementonvec = relfp->getRelatedToObjects(jets->at(ijet));
+  if (elementonvec.size() > 0 ) {
+    MCParticle* mcp  = dynamic_cast<MCParticle*>(elementonvec[0]);
+    return mcp;
+  } else {
+    return NULL;
+  }
+
+}
+const MCParticleVec& TrueJet_Parser::elementons_final_cn(int ifcn){
+  mcpartvec->clear();
+
+  MCParticleVec* elementons= mcpartvec;
+  IntVec jetind=jets_of_final_cn(ifcn );
+  for (unsigned kk=0 ; kk <jetind.size() ; kk++ ) {
+    MCParticle* mcp=final_elementon(jetind[kk]);
+    if ( mcp != NULL ) {
+      elementons->push_back(mcp);
+    }
+  }
+  return *elementons;
+}
+
+const MCParticleVec& TrueJet_Parser::elementons_initial_cn(int iicn){
+  mcpartvec->clear();
+
+  MCParticleVec* elementons= mcpartvec;
+  IntVec jetind=jets_of_initial_cn(iicn );
+  for (unsigned kk=0 ; kk <jetind.size() ; kk++ ) {
+    MCParticle* mcp=initial_elementon(jetind[kk]);
+    if ( mcp != NULL ) {
+      elementons->push_back(mcp);
+    }
+  }
+  return *elementons;
+}
+
+void TrueJet_Parser::getall( LCEvent * event ) {
+
+
+    evt=event;
+     // get TrueJets
+    try{
+      tjcol = evt->getCollection( _trueJetCollectionName);
+      if (  tjcol->getNumberOfElements() == 0 ) { return ; }
+    }
+    catch( lcio::DataNotAvailableException e )
+    {
+      streamlog_out(WARNING) <<    _trueJetCollectionName  << " collection not available 1" << std::endl;
+      tjcol = NULL;
+    }
+
+    jets=getJets();
+
+     // get  FinalColourNeutrals
+    try{
+      fcncol = evt->getCollection( _finalColourNeutralCollectionName);
+    }
+    catch( lcio::DataNotAvailableException e )
+    {
+        streamlog_out(WARNING) <<    _finalColourNeutralCollectionName << " collection not available" << std::endl;
+        fcncol = NULL;
+    }
+
+    finalcns=getFinalcn();
+
+     // get  InitialColourNeutrals
+    try{
+      icncol = evt->getCollection( _initialColourNeutralCollectionName);
+    }
+    catch( lcio::DataNotAvailableException e )
+    {
+        streamlog_out(WARNING) <<    _initialColourNeutralCollectionName << " collection not available" << std::endl;
+        icncol = NULL;
+    }
+
+    initialcns=getInitialcn();
+
+     // get  FinalColourNeutralLink
+    LCCollection* fcnlcol = NULL;
+    try{
+      fcnlcol  = evt->getCollection(  _finalColourNeutralLink );
+    }
+    catch( lcio::DataNotAvailableException e )
+    {
+        streamlog_out(WARNING) <<  _finalColourNeutralLink   << " collection not available" << std::endl;
+        fcnlcol  = NULL;
+    }
+    relfcn = new LCRelationNavigator( fcnlcol );
+
+     // get  InitialColourNeutralLink
+    LCCollection* icnlcol = NULL;
+    try{
+      icnlcol  = evt->getCollection(  _initialColourNeutralLink );
+    }
+    catch( lcio::DataNotAvailableException e )
+    {
+        streamlog_out(WARNING) <<  _initialColourNeutralLink  << " collection not available" << std::endl;
+        fcnlcol  = NULL;
+    }
+    relicn = new LCRelationNavigator( icnlcol );
+
+     // get  FinalElementonLink
+    LCCollection* fplcol = NULL;
+    try{
+      fplcol  = evt->getCollection(  _finalElementonLink );
+    }
+    catch( lcio::DataNotAvailableException e )
+    {
+        streamlog_out(WARNING) <<  _finalElementonLink   << " collection not available" << std::endl;
+        fcnlcol  = NULL;
+    }
+    relfp = new LCRelationNavigator( fplcol );
+
+     // get  InitialElementonLink
+    LCCollection* iplcol = NULL;
+    try{
+      iplcol  = evt->getCollection(  _initialElementonLink );
+    }
+    catch( lcio::DataNotAvailableException e )
+    {
+        streamlog_out(WARNING) <<  _initialElementonLink   << " collection not available" << std::endl;
+        fcnlcol  = NULL;
+    }
+    relip = new LCRelationNavigator( iplcol );
+
+     // get  TrueJetPFOLink
+    LCCollection* tjrecolcol = NULL;
+    try{
+      tjrecolcol  = evt->getCollection(  _trueJetPFOLink );
+    }
+    catch( lcio::DataNotAvailableException e )
+    {
+        streamlog_out(WARNING) <<  _trueJetPFOLink   << " collection not available" << std::endl;
+        fcnlcol  = NULL;
+    }
+    reltjreco = new LCRelationNavigator( tjrecolcol );
+
+
+     // get  TrueJetMCParticleLink
+    LCCollection* tjmcplcol = NULL;
+    try{
+      tjmcplcol  = evt->getCollection(  _trueJetMCParticleLink );
+    }
+    catch( lcio::DataNotAvailableException e )
+    {
+        streamlog_out(WARNING) <<  _trueJetMCParticleLink   << " collection not available" << std::endl;
+        fcnlcol  = NULL;
+    }
+    reltjmcp = new LCRelationNavigator( tjmcplcol );
+    reltrue_tj =NULL ;
+
+}
+void TrueJet_Parser::delall( ) {
+    if (  relfcn!= NULL ) delete relfcn;
+    if (  relicn!= NULL ) delete relicn;
+    if (  relfp!= NULL ) delete relfp;
+    if (  relip!= NULL ) delete relip;
+    if (  reltjreco != NULL) delete reltjreco;
+    if (  reltjmcp != NULL) delete reltjmcp;
+    if (  jets != NULL) delete  jets;
+    if (  finalcns != NULL) delete  finalcns;
+    if (  initialcns!= NULL ) delete   initialcns;
+    if ( reltrue_tj != NULL ) delete reltrue_tj;
+}


### PR DESCRIPTION

BEGINRELEASENOTES
- Move `TrueJet_Parser` utility class from MarlinReco to MarlinUtil.
  - Make it possible to use this in analysis code outside of MarlinReco

ENDRELEASENOTES

@gaede @MikaelBerggren I simply copied the two files here without preserving the commit history. Is this something that we would want?