### PR TITLE
Remove no longer supported gcc8 based CI workflow

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -9,9 +9,6 @@ jobs:
       matrix:
         COMPILER: [gcc10, clang11]
         LCG: [100]
-        include:
-          - COMPILER: gcc8
-            LCG: 99python2
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION

BEGINRELEASENOTES
- Remove the no longer supported gcc8 based CI workflow.

ENDRELEASENOTES