### PR TITLE
Add track and cluster weights decoders and their comparators

### DIFF
--- a/source/include/MarlinUtil.h
+++ b/source/include/MarlinUtil.h
@@ -67,7 +67,7 @@ namespace MarlinUtil {
    * 
    */
   inline float getTrackWeight(float encodedWeight){
-      return ( int(encodedWeight) % 10000 ) / 1000.;
+      return float( int(encodedWeight) % 10000 ) / 1000.f;
   }
 
 
@@ -76,7 +76,7 @@ namespace MarlinUtil {
    * ReconstructedParticle-MCParticle (or vise-versa) type of relations.
    */
   inline float getClusterWeight(float encodedWeight){
-      return ( int(encodedWeight) / 10000 ) / 1000.;
+      return float( int(encodedWeight) / 10000 ) / 1000.f;
   }
 
 
@@ -95,9 +95,6 @@ namespace MarlinUtil {
   inline bool compareClusterWeights(float a, float b) {
     return getClusterWeight(a) < getClusterWeight(b);
   }
-
-
-  // ...
 
 }
 

--- a/source/include/MarlinUtil.h
+++ b/source/include/MarlinUtil.h
@@ -79,21 +79,12 @@ namespace MarlinUtil {
       return float( int(encodedWeight) / 10000 ) / 1000.f;
   }
 
-
-  /** Comparator function to compare weights with track weight encoding trackwgt =
-   * (int(wgt)%10000)/1000. set by the MarlinReco/Analysis/RecoMCTruthLink/include/RecoMCTruthLinker.h 
-   * for the ReconstructedParticle-MCParticle (or vise-versa) type of relations.
+  /** Return a single number that encodes in itself two numbers representing track and cluster weights given as arguments.
+   * For tracks and clusters, the weight is the sum of hits from the considered true particle divided by the sum of all hits.
+   * It is used inside RecoMCTruthLinker.
    */
-  inline bool compareTrackWeights(float a, float b) {
-    return getTrackWeight(a) < getTrackWeight(b);
-  }
-
-  /** Comparator function to compare weights with cluster weight encoding clusterwgt = (int(wgt)/10000)/1000.
-   * set by the MarlinReco/Analysis/RecoMCTruthLink/include/RecoMCTruthLinker.h 
-   * for the ReconstructedParticle-MCParticle (or vise-versa) type of relations.
-   */
-  inline bool compareClusterWeights(float a, float b) {
-    return getClusterWeight(a) < getClusterWeight(b);
+  inline float encodeTrackAndClusterWeights(const float trackWeight,const float clusterWeight){
+      return int(clusterWeight*1000)*10000 + int(trackWeight*1000);
   }
 
 }

--- a/source/include/MarlinUtil.h
+++ b/source/include/MarlinUtil.h
@@ -62,7 +62,7 @@ namespace MarlinUtil {
 
 
   /** Return track weight contribution encoded as trackwgt = (int(wgt)%10000)/1000. by
-   * the MarlinReco/Analysis/RecoMCTruthLink/include/RecoMCTruthLinker.h for the
+   * the encodeTrackAndClusterWeights function for the
    * ReconstructedParticle-MCParticle (or vise-versa) type of relations.
    * 
    */
@@ -72,7 +72,7 @@ namespace MarlinUtil {
 
 
   /** Return cluster weight contribution encoded as clusterwgt = (int(wgt)/10000)/1000. by
-   * the MarlinReco/Analysis/RecoMCTruthLink/include/RecoMCTruthLinker.h for the
+   * the encodeTrackAndClusterWeights function for the
    * ReconstructedParticle-MCParticle (or vise-versa) type of relations.
    */
   inline float getClusterWeight(float encodedWeight){

--- a/source/include/MarlinUtil.h
+++ b/source/include/MarlinUtil.h
@@ -61,6 +61,44 @@ namespace MarlinUtil {
   double getEnergyDepositedInFullCalorimeter(lcio::LCEvent* evt);
 
 
+  /** Return track weight contribution encoded as trackwgt = (int(wgt)%10000)/1000. by
+   * the MarlinReco/Analysis/RecoMCTruthLink/include/RecoMCTruthLinker.h for the
+   * ReconstructedParticle-MCParticle (or vise-versa) type of relations.
+   * 
+   */
+  inline float getTrackWeight(float encodedWeight){
+      return ( int(encodedWeight) % 10000 ) / 1000.;
+  }
+
+
+  /** Return cluster weight contribution encoded as clusterwgt = (int(wgt)/10000)/1000. by
+   * the MarlinReco/Analysis/RecoMCTruthLink/include/RecoMCTruthLinker.h for the
+   * ReconstructedParticle-MCParticle (or vise-versa) type of relations.
+   */
+  inline float getClusterWeight(float encodedWeight){
+      return ( int(encodedWeight) / 10000 ) / 1000.;
+  }
+
+
+  /** Comparator function to compare weights with track weight encoding trackwgt =
+   * (int(wgt)%10000)/1000. set by the MarlinReco/Analysis/RecoMCTruthLink/include/RecoMCTruthLinker.h 
+   * for the ReconstructedParticle-MCParticle (or vise-versa) type of relations.
+   */
+  inline bool compareTrackWeights(float a, float b) {
+    return getTrackWeight(a) < getTrackWeight(b);
+  }
+
+  /** Comparator function to compare weights with cluster weight encoding clusterwgt = (int(wgt)/10000)/1000.
+   * set by the MarlinReco/Analysis/RecoMCTruthLink/include/RecoMCTruthLinker.h 
+   * for the ReconstructedParticle-MCParticle (or vise-versa) type of relations.
+   */
+  inline bool compareClusterWeights(float a, float b) {
+    return getClusterWeight(a) < getClusterWeight(b);
+  }
+
+
+  // ...
+
 }
 
 


### PR DESCRIPTION
Following change in `LCRelationNavigator` here: https://github.com/iLCSoft/LCIO/pull/163

Here are added functions to derive "Track" and "Cluster" weights from PFO-MCParticle LCRelation collection, which are encoded (and documented ONLY) by this processor: https://github.com/iLCSoft/MarlinReco/blob/0ed180e0ee3264f733bd86420debc6533b84e644/Analysis/RecoMCTruthLink/include/RecoMCTruthLinker.h#L27-L44

Also comparator functions are added to make more convenient use with the new LCRelationNavigator.



BEGINRELEASENOTES

- Add function to extract decoded Track and Cluster weights from encoded LCRelation collection for PFO/MCParticles.
- Add comparator functions for these weights encodings

ENDRELEASENOTES