### PR TITLE
Add key4hep based CI workflows

### DIFF
--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -1,0 +1,36 @@
+name: key4hep
+on: [push, pull_request]
+
+jobs:
+  key4hep:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        release: ["sw.hsf.org/key4hep",
+                  "sw-nightlies.hsf.org/key4hep"]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: aidasoft/run-lcg-view@v4
+      with:
+        container: centos7
+        view-path: /cvmfs/${{ matrix.release }}
+        run: |
+          echo "::group::Run CMake"
+          mkdir build
+          cd build
+          cmake -GNinja \
+            -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " \
+            -DINSTALL_DOC=ON \
+            -DUSE_EXTERNAL_CATCH2=ON \
+            ..
+          echo "::endgroup::"
+          echo "::group::Build"
+          ninja -k0
+          echo "::endgroup::"
+          echo "::group::Test"
+          ctest --output-on-failure
+          echo "::endgroup::"
+          echo "::group::Install"
+          ninja install


### PR DESCRIPTION

BEGINRELEASENOTES
- Add a CI workflow based on the Key4hep release and nightly builds

ENDRELEASENOTES