### PR TITLE
Update CI to latest clicdp nightlies and key4hep workflow, better Catch2 discovery

### DIFF
--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -1,36 +1,18 @@
-name: key4hep
+name: keyh4ep
 on: [push, pull_request]
 
 jobs:
-  key4hep:
+  build-and-test:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
-        release: ["sw.hsf.org/key4hep",
-                  "sw-nightlies.hsf.org/key4hep"]
+        build_type: ["release", "nightly"]
+        image: ["alma9", "ubuntu22", "centos7"]
+      fail-fast: false
+
     steps:
-    - uses: actions/checkout@v3
-    - uses: cvmfs-contrib/github-action-cvmfs@v3
-    - uses: aidasoft/run-lcg-view@v4
+    - uses: actions/checkout@v4
+    - uses: key4hep/key4hep-actions/key4hep-build@main
       with:
-        container: centos7
-        view-path: /cvmfs/${{ matrix.release }}
-        run: |
-          echo "::group::Run CMake"
-          mkdir build
-          cd build
-          cmake -GNinja \
-            -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " \
-            -DINSTALL_DOC=ON \
-            -DUSE_EXTERNAL_CATCH2=ON \
-            ..
-          echo "::endgroup::"
-          echo "::group::Build"
-          ninja -k0
-          echo "::endgroup::"
-          echo "::group::Test"
-          ctest --output-on-failure
-          echo "::endgroup::"
-          echo "::group::Install"
-          ninja install
+        build_type: ${{ matrix.build_type }}
+        image: ${{ matrix.image }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,12 +7,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        COMPILER: [gcc10, clang11]
-        LCG: [100]
+        COMPILER: [gcc11]
+        LCG: [104]
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: actions/checkout@v4
+    - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: aidasoft/run-lcg-view@v4
       with:
         view-path: "/cvmfs/clicdp.cern.ch/iLCSoft/lcg/${{ matrix.LCG }}/nightly/x86_64-centos7-${{ matrix.COMPILER }}-opt"
@@ -20,7 +20,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -GNinja -C ${ILCSOFT}/ILCSoft.cmake -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " -DINSTALL_DOC=ON -DUSE_EXTERNAL_CATCH2=OFF ..
+          cmake -GNinja -C ${ILCSOFT}/ILCSoft.cmake -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " ..
           ninja -k0
           ctest --output-on-failure
           ninja install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,9 @@ SET_SOURCE_FILES_PROPERTIES( "./source/src/ann/kd_pr_search.cpp" PROPERTIES COMP
 #ADD_SHARED_LIBRARY( ${PROJECT_NAME}_ann ${ann_library_sources} )
 #INSTALL_SHARED_LIBRARY( ${PROJECT_NAME}_ann DESTINATION lib )
 
-option(USE_EXTERNAL_CATCH2 "Link against an external Catch2 v3 static library, otherwise build it locally" ON)
+option(USE_EXTERNAL_CATCH2 "Link against an external Catch2 v3 static library, otherwise build it locally" AUTO)
+set(USE_EXTERNAL_CATCH2 AUTO CACHE STRING "Link against an external Catch2 v3 static library, otherwise build it locally")
+set_property(CACHE USE_EXTERNAL_CATCH2 PROPERTY STRINGS AUTO ON OFF)
 
 IF( BUILD_TESTING )
   ADD_SUBDIRECTORY(source/tests)

--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -11,9 +11,20 @@ ENDMACRO()
 ADD_MARLINUTIL_TEST( testmarlinutil )
 
 #--- Unit test setup. Use existing Catch2 or fetch a suitable version and build it
-if(USE_EXTERNAL_CATCH2)
-  FIND_PACKAGE(Catch2 3.0.0 REQUIRED)
+if(CMAKE_CXX_STANDARD GREATER_EQUAL 20)
+  set(CATCH2_MIN_VERSION 3.4)
 else()
+  set(CATCH2_MIN_VERSION 3.1)
+endif()
+if(USE_EXTERNAL_CATCH2)
+  if (USE_EXTERNAL_CATCH2 STREQUAL AUTO)
+    find_package(Catch2 ${CATCH2_MIN_VERSION})
+  else()
+    find_package(Catch2 ${CATCH2_MIN_VERSION} REQUIRED)
+  endif()
+endif()
+
+if(NOT Catch2_FOUND)
   MESSAGE(STATUS "Fetching local copy of Catch2 library for unit-tests...")
   # Build Catch2 with the default flags, to avoid generating warnings when we
   # build it


### PR DESCRIPTION

BEGINRELEASENOTES
- Update CI to use latest clicdp nightlies and central key4hep build workflows
- Make Catch2 discovery a bit more robust and easier to use

ENDRELEASENOTES