### PR TITLE
Add SelectNthEventsProcessor

### DIFF
--- a/source/include/SelectNthEventsProcessor.h
+++ b/source/include/SelectNthEventsProcessor.h
@@ -1,0 +1,75 @@
+#ifndef SelectNthEventsProcessor_h
+#define SelectNthEventsProcessor_h 1
+
+#include "marlin/Processor.h"
+#include "lcio.h"
+#include <string>
+
+
+using namespace lcio ;
+using namespace marlin ;
+
+
+/** Select a number n, every nth event will have the processor ReturnValue set to true, all others to false.
+ *  The selection can be inverted and the starting event can be offset from event 0.
+ *  Use in steering file in execute section via
+ *  <if condition="MySelectNthEventsProcessor">
+ *    <processor name="MyAnalysisProcessor">
+ *  </if>
+ *
+ * @param nEventToSelect: Integer number n. Every nth event's ReturnValue is set to true.
+ * @param SelectionOffset: Sets an offset m, so the Return Value of the mth event (and every nth before and after it) is set to true.
+ * @param InvertSelection: Inverts the ReturnValue. If true, every nth event's ReturnValue is false, all others are true.
+ * 
+ * @author U Einhaus, DESY
+ * @version $Id: SelectNthEventsProcessor.h, v1.0 2024-01-21 $
+ */
+
+class SelectNthEventsProcessor : public Processor {
+  
+ public:
+  
+  virtual Processor*  newProcessor() { return new SelectNthEventsProcessor ; }
+  
+  
+  SelectNthEventsProcessor() ;
+  
+  /** Called at the begin of the job before anything is read.
+   * Use to initialize the processor, e.g. book histograms.
+   */
+  virtual void init() ;
+  
+  /** Called for every run.
+   */
+  virtual void processRunHeader( LCRunHeader* ) {};
+  
+  /** Called for every event - the working horse.
+   */
+  virtual void processEvent( LCEvent* );
+  
+  
+  virtual void check( LCEvent* ) {};
+  
+  
+  /** Called after data processing for clean up.
+   */
+  virtual void end() ;
+  
+  
+ protected:
+
+  int _nRun=0;
+  int _nEvt=0;
+  int _nEvtProc=0;
+  int _nEvtSkip=0;
+  
+  int _nEventToSelect=1;
+  int _selectionOffset=0;
+  bool _invertSelection=false;
+
+} ;
+
+#endif
+
+
+

--- a/source/src/SelectNthEventsProcessor.cc
+++ b/source/src/SelectNthEventsProcessor.cc
@@ -1,0 +1,56 @@
+#include "SelectNthEventsProcessor.h"
+#include <iostream>
+
+using namespace lcio ;
+using namespace marlin ;
+
+
+SelectNthEventsProcessor aSelectNthEventsProcessor ;
+
+SelectNthEventsProcessor::SelectNthEventsProcessor() : Processor("SelectNthEventsProcessor"){
+  
+  _description = "SelectNthEventsProcessor Processor sets ReturnValue true for every nth event. The selection can be offset and/or inverted.";
+  
+
+  registerProcessorParameter( "nEventToSelect", 
+			      "Integer number n, every nth event's ReturnValue is set to true; default: 1",
+			      _nEventToSelect,
+			      int(1) );
+
+  registerProcessorParameter( "SelectionOffset",
+			      "Sets an offset m, so the Return Value of the mth event (and every nth before and after it) is set to true; default: 0",
+			      _selectionOffset,
+			      int(0) );
+
+  registerProcessorParameter( "InvertSelection",
+			      "Inverts the ReturnValue; if true, every nth event's ReturnValue is false, all others are true; default: false",
+			      _invertSelection,
+			      false );
+}
+
+void SelectNthEventsProcessor::init(){
+  // usually a good idea to
+  printParameters() ;
+
+  _nRun = 0;
+  _nEvt = 0;
+  _nEvtProc = 0;
+  _nEvtSkip = 0;
+  
+}
+
+void SelectNthEventsProcessor::processEvent( LCEvent* ){
+
+  bool skip ( (_nEvt-_selectionOffset)%_nEventToSelect!=0 );
+  if( _invertSelection ) skip = !skip;
+
+  setReturnValue(!skip);
+
+  ++_nEvt;
+  if (skip) ++_nEvtSkip;
+  else ++_nEvtProc;
+}
+
+void SelectNthEventsProcessor::end(){ 
+  streamlog_out(MESSAGE) << "Total Events: " << _nEvt << ",  Events processed: " << _nEvtProc << ",  Events skipped: " << _nEvtSkip << std::endl;
+}


### PR DESCRIPTION

BEGINRELEASENOTES
- Adds SelectNthEventsProcessor.
- This sets its own processor ReturnValue to true or false, depending on chosen parameters, which can be used in the Marlin steering file to use a particular sub-set of a sample.
- Via the InvertSelection parameter this can be easily inverted, which is convenient for training vs. inference of ML models.
ENDRELEASENOTES