### PR TITLE
Fix potential indexing issue and remove CentOS7 from CI workflows

### DIFF
--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         build_type: ["release", "nightly"]
-        image: ["alma9", "ubuntu22", "centos7"]
+        image: ["alma9", "ubuntu22"]
       fail-fast: false
 
     steps:

--- a/source/src/WeightedPoints3D.cc
+++ b/source/src/WeightedPoints3D.cc
@@ -885,8 +885,8 @@ void WeightedPoints3D::propagateVecErrorsCartesian(){
     Dmat[1][1] =  sin(phi)*cos(theta) ;
     Dmat[2][1] =  -sin(theta) ;
     double thph_dmat [2][3];
-    for ( int i =0 ; i < 3 ; i++ ) {
-      for ( int j=0 ; j < 2 ; j++ ) {
+    for ( int i =0 ; i < 2 ; i++ ) {
+      for ( int j=0 ; j < 3 ; j++ ) {
         thph_dmat [i][j] = 0. ;
         for (int k=0 ; k < 2 ; k++ ) {
           thph_dmat [i][j] += _theta_phi_cov[i][k][l]*Dmat[j][k];


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix a potential indexing issue in `WeightedPoints3D`
- Remove no longer supported CentOS7 from Key4hep workflows

ENDRELEASENOTES

The indexing issue does look a bit worse than it actually is, since it effectively cancels itself; Quoting from some email exchange with @MikaelBerggren 

> It's a bit of a mess with this reversed order of matrix indices in C w.r.t. mathematical notation. Writing down what should be done (cf. the two out-commented fortran lines) with Einstein notation (sum over repeated indices) and using that both _theta_phi_cov and _xyz_cov are symmetric, and the same swap of the correct order of indices are done on lines 892 and 900 (effectively cancelling the error), the minimal correct fix is to swap the loop-bounds (3 -> 2 on line 888, 2->3 on line 889).