### PR TITLE
Fetch Catch2 version that can be built

### DIFF
--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -34,7 +34,7 @@ if(NOT Catch2_FOUND)
   fETCHCONTENT_DECLARE(
     Catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_TAG        v3.0.1
+    GIT_TAG        v${CATCH2_MIN_VERSION}.0
     )
   FETCHCONTENT_MAKEAVAILABLE(Catch2)
   set(CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras ${CMAKE_MODULE_PATH})


### PR DESCRIPTION

BEGINRELEASENOTES
- Make sure to fetch a Catch2 version that can actually be built with the required C++ standard.

ENDRELEASENOTES

After this, the fetched version will at least match the one that we would require via `find_package` otherwise.