### PR TITLE
Use std::unique_ptr when possible in TrueJet_Parser

### DIFF
--- a/source/include/TrueJet_Parser.h
+++ b/source/include/TrueJet_Parser.h
@@ -10,6 +10,7 @@
 #include "IMPL/LCCollectionVec.h"
 #include <IMPL/ReconstructedParticleImpl.h>
 #include <IMPL/ParticleIDImpl.h>
+#include <memory>
 #include <string>
 
 using namespace lcio ;
@@ -250,15 +251,15 @@ class TrueJet_Parser {
                                  // while in the other way jetindex( truejet-object ) gives the index.
 
 
-    LCRelationNavigator* relfcn{};      // a truejet to final colour neutral(s)    [ ReconstructedParticle:s ]
-    LCRelationNavigator* relicn{};      // a truejet to initial colour neutral(s)   [ ReconstructedParticle:s ]
+    std::unique_ptr<LCRelationNavigator> relfcn;      // a truejet to final colour neutral(s)    [ ReconstructedParticle:s ]
+    std::unique_ptr<LCRelationNavigator> relicn;      // a truejet to initial colour neutral(s)   [ ReconstructedParticle:s ]
 
-    LCRelationNavigator* relfp{};       // a truejet to its final quarks/leptons   [ MCParticle:s ]
-    LCRelationNavigator* relip{};       // a truejet to its initial quarks/leptons [ MCParticle:s ]
+    std::unique_ptr<LCRelationNavigator> relfp;       // a truejet to its final quarks/leptons   [ MCParticle:s ]
+    std::unique_ptr<LCRelationNavigator> relip;       // a truejet to its initial quarks/leptons [ MCParticle:s ]
 
 
-    LCRelationNavigator* reltjreco{};   // a truejet to all seen particles in it    [ ReconstructedParticle:s ]
-    LCRelationNavigator* reltjmcp{};    // a truejet to all true particles in it   [ MCParticle:s ]
+    std::unique_ptr<LCRelationNavigator> reltjreco;   // a truejet to all seen particles in it    [ ReconstructedParticle:s ]
+    std::unique_ptr<LCRelationNavigator> reltjmcp;    // a truejet to all true particles in it   [ MCParticle:s ]
 
 
                                  // Example:
@@ -272,14 +273,14 @@ class TrueJet_Parser {
                                 //  seen_partics(ijet) returns a ReconstructedParticlVec of all
                                 //  PFOs belonging to jet ijet)
 
-    LCRelationNavigator* reltrue_tj{};  // = RecoMCTruthLink
+    std::unique_ptr<LCRelationNavigator> reltrue_tj;  // = RecoMCTruthLink
 
     LCCollection* tjcol{};
     LCCollection* fcncol{};
     LCCollection* icncol{};
-    ReconstructedParticleVec* jets{};
-    ReconstructedParticleVec* finalcns{};
-    ReconstructedParticleVec* initialcns{};
+    std::unique_ptr<ReconstructedParticleVec> jets;
+    std::unique_ptr<ReconstructedParticleVec> finalcns;
+    std::unique_ptr<ReconstructedParticleVec> initialcns;
 
  protected:
  /**  input collection names */

--- a/source/include/TrueJet_Parser.h
+++ b/source/include/TrueJet_Parser.h
@@ -43,6 +43,7 @@ class TrueJet_Parser {
                                   // the three above individually. Also all navigators are set up
                                   // with this call - See below.
 
+  void delall() ;                 // Tidy up, to be called at end of each event.
 
   int njets() { return tjcol->getNumberOfElements(); };
                                   // Get the total number of true jets in the event

--- a/source/include/TrueJet_Parser.h
+++ b/source/include/TrueJet_Parser.h
@@ -43,7 +43,6 @@ class TrueJet_Parser {
                                   // the three above individually. Also all navigators are set up
                                   // with this call - See below.
 
-  void delall() ;                 // Tidy up, to be called at end of each event.
 
   int njets() { return tjcol->getNumberOfElements(); };
                                   // Get the total number of true jets in the event

--- a/source/src/TrueJet_Parser.cc
+++ b/source/src/TrueJet_Parser.cc
@@ -662,15 +662,3 @@ void TrueJet_Parser::getall( LCEvent * event ) {
     reltrue_tj.reset();
 
 }
-void TrueJet_Parser::delall( ) {
-    relfcn.reset();
-    relicn.reset();
-    relfp.reset();
-    relip.reset();
-    reltjreco.reset();
-    reltjmcp.reset();
-    jets.reset();
-    finalcns.reset();
-    initialcns.reset();
-    reltrue_tj.reset();
-}

--- a/source/src/TrueJet_Parser.cc
+++ b/source/src/TrueJet_Parser.cc
@@ -23,18 +23,7 @@ using namespace marlin ;
 struct MCPseen : LCIntExtension<MCPseen> {} ;
 
 
-  TrueJet_Parser::TrueJet_Parser() :
-    relfcn(),
-    relicn(),
-    relfp(),
-    relip(),
-    reltjreco(),
-    reltjmcp(),
-    reltrue_tj(),
-    jets(),
-    finalcns(),
-    initialcns()
-  {
+TrueJet_Parser::TrueJet_Parser() {
     m_intvec=new IntVec()    ;
     m_mcpartvec=new MCParticleVec()    ;
     _COUNT_FSR=1;

--- a/source/src/TrueJet_Parser.cc
+++ b/source/src/TrueJet_Parser.cc
@@ -23,7 +23,18 @@ using namespace marlin ;
 struct MCPseen : LCIntExtension<MCPseen> {} ;
 
 
-TrueJet_Parser::TrueJet_Parser() {
+  TrueJet_Parser::TrueJet_Parser() :
+    relfcn(),
+    relicn(),
+    relfp(),
+    relip(),
+    reltjreco(),
+    reltjmcp(),
+    reltrue_tj(),
+    jets(),
+    finalcns(),
+    initialcns()
+  {
     m_intvec=new IntVec()    ;
     m_mcpartvec=new MCParticleVec()    ;
     _COUNT_FSR=1;

--- a/source/src/TrueJet_Parser.cc
+++ b/source/src/TrueJet_Parser.cc
@@ -139,7 +139,7 @@ const double* TrueJet_Parser::p4quark(int ijet) {
 
 
 double TrueJet_Parser::Etrueseen(int ijet) {
-  if (  reltrue_tj == 0 ) {
+  if ( !reltrue_tj ) {
     LCCollection* rmclcol = NULL;
     try{
      rmclcol = m_evt->getCollection( get_recoMCTruthLink() );
@@ -149,7 +149,7 @@ double TrueJet_Parser::Etrueseen(int ijet) {
       streamlog_out(WARNING) << get_recoMCTruthLink()   << " collection not available" << std::endl;
         rmclcol = NULL;
     }
-    reltrue_tj = new LCRelationNavigator( rmclcol );
+    reltrue_tj = std::make_unique<LCRelationNavigator>( rmclcol );
   }
   LCObjectVec mcpvec = reltjmcp->getRelatedToObjects( jets->at(ijet) );
   double E=0.0;
@@ -180,7 +180,7 @@ double TrueJet_Parser::Mtrueseen(int ijet) {
   return M ;
 }
 const double* TrueJet_Parser::ptrueseen(int ijet) {
-  if (  reltrue_tj == 0 ) {
+  if ( !reltrue_tj ) {
     LCCollection* rmclcol = NULL;
      try{
       rmclcol = m_evt->getCollection( get_recoMCTruthLink() );
@@ -190,7 +190,7 @@ const double* TrueJet_Parser::ptrueseen(int ijet) {
       streamlog_out(WARNING) << get_recoMCTruthLink()   << " collection not available" << std::endl;
         rmclcol = NULL;
     }
-    reltrue_tj = new LCRelationNavigator( rmclcol );
+    reltrue_tj = std::make_unique<LCRelationNavigator>( rmclcol );
   }
   LCObjectVec mcpvec = reltjmcp->getRelatedToObjects( jets->at(ijet) );
   m_p3[0]=0 ; m_p3[1]=0 ; m_p3[2]=0 ;
@@ -551,7 +551,7 @@ void TrueJet_Parser::getall( LCEvent * event ) {
       tjcol = NULL;
     }
 
-    jets=getJets();
+    jets.reset(getJets());
 
      // get  FinalColourNeutrals
     try{
@@ -563,7 +563,7 @@ void TrueJet_Parser::getall( LCEvent * event ) {
         fcncol = NULL;
     }
 
-    finalcns=getFinalcn();
+    finalcns.reset(getFinalcn());
 
      // get  InitialColourNeutrals
     try{
@@ -575,7 +575,7 @@ void TrueJet_Parser::getall( LCEvent * event ) {
         icncol = NULL;
     }
 
-    initialcns=getInitialcn();
+    initialcns.reset(getInitialcn());
 
      // get  FinalColourNeutralLink
     LCCollection* fcnlcol = NULL;
@@ -587,7 +587,7 @@ void TrueJet_Parser::getall( LCEvent * event ) {
         streamlog_out(WARNING) <<  _finalColourNeutralLink   << " collection not available" << std::endl;
         fcnlcol  = NULL;
     }
-    relfcn = new LCRelationNavigator( fcnlcol );
+    relfcn = std::make_unique<LCRelationNavigator>( fcnlcol );
 
      // get  InitialColourNeutralLink
     LCCollection* icnlcol = NULL;
@@ -599,7 +599,7 @@ void TrueJet_Parser::getall( LCEvent * event ) {
         streamlog_out(WARNING) <<  _initialColourNeutralLink  << " collection not available" << std::endl;
         fcnlcol  = NULL;
     }
-    relicn = new LCRelationNavigator( icnlcol );
+    relicn = std::make_unique<LCRelationNavigator>( icnlcol );
 
      // get  FinalElementonLink
     LCCollection* fplcol = NULL;
@@ -611,7 +611,7 @@ void TrueJet_Parser::getall( LCEvent * event ) {
         streamlog_out(WARNING) <<  _finalElementonLink   << " collection not available" << std::endl;
         fcnlcol  = NULL;
     }
-    relfp = new LCRelationNavigator( fplcol );
+    relfp = std::make_unique<LCRelationNavigator>( fplcol );
 
      // get  InitialElementonLink
     LCCollection* iplcol = NULL;
@@ -623,7 +623,7 @@ void TrueJet_Parser::getall( LCEvent * event ) {
         streamlog_out(WARNING) <<  _initialElementonLink   << " collection not available" << std::endl;
         fcnlcol  = NULL;
     }
-    relip = new LCRelationNavigator( iplcol );
+    relip = std::make_unique<LCRelationNavigator>( iplcol );
 
      // get  TrueJetPFOLink
     LCCollection* tjrecolcol = NULL;
@@ -635,7 +635,7 @@ void TrueJet_Parser::getall( LCEvent * event ) {
         streamlog_out(WARNING) <<  _trueJetPFOLink   << " collection not available" << std::endl;
         fcnlcol  = NULL;
     }
-    reltjreco = new LCRelationNavigator( tjrecolcol );
+    reltjreco = std::make_unique<LCRelationNavigator>( tjrecolcol );
 
 
      // get  TrueJetMCParticleLink
@@ -648,19 +648,19 @@ void TrueJet_Parser::getall( LCEvent * event ) {
         streamlog_out(WARNING) <<  _trueJetMCParticleLink   << " collection not available" << std::endl;
         fcnlcol  = NULL;
     }
-    reltjmcp = new LCRelationNavigator( tjmcplcol );
-    reltrue_tj =NULL ;
+    reltjmcp = std::make_unique<LCRelationNavigator>( tjmcplcol );
+    reltrue_tj.reset();
 
 }
 void TrueJet_Parser::delall( ) {
-    if (  relfcn!= NULL ) delete relfcn;
-    if (  relicn!= NULL ) delete relicn;
-    if (  relfp!= NULL ) delete relfp;
-    if (  relip!= NULL ) delete relip;
-    if (  reltjreco != NULL) delete reltjreco;
-    if (  reltjmcp != NULL) delete reltjmcp;
-    if (  jets != NULL) delete  jets;
-    if (  finalcns != NULL) delete  finalcns;
-    if (  initialcns!= NULL ) delete   initialcns;
-    if ( reltrue_tj != NULL ) delete reltrue_tj;
+    relfcn.reset();
+    relicn.reset();
+    relfp.reset();
+    relip.reset();
+    reltjreco.reset();
+    reltjmcp.reset();
+    jets.reset();
+    finalcns.reset();
+    initialcns.reset();
+    reltrue_tj.reset();
 }

--- a/source/src/TrueJet_Parser.cc
+++ b/source/src/TrueJet_Parser.cc
@@ -651,3 +651,15 @@ void TrueJet_Parser::getall( LCEvent * event ) {
     reltrue_tj.reset();
 
 }
+void TrueJet_Parser::delall( ) {
+    relfcn.reset();
+    relicn.reset();
+    relfp.reset();
+    relip.reset();
+    reltjreco.reset();
+    reltjmcp.reset();
+    jets.reset();
+    finalcns.reset();
+    initialcns.reset();
+    reltrue_tj.reset();
+}

--- a/source/src/TrueJet_Parser.cc
+++ b/source/src/TrueJet_Parser.cc
@@ -23,8 +23,18 @@ using namespace marlin ;
 struct MCPseen : LCIntExtension<MCPseen> {} ;
 
 
-  TrueJet_Parser::TrueJet_Parser() {
-
+  TrueJet_Parser::TrueJet_Parser() :
+    relfcn(),
+    relicn(),
+    relfp(),
+    relip(),
+    reltjreco(),
+    reltjmcp(),
+    reltrue_tj(),
+    jets(),
+    finalcns(),
+    initialcns()
+  {
     m_intvec=new IntVec()    ;
     m_mcpartvec=new MCParticleVec()    ;
     _COUNT_FSR=1;


### PR DESCRIPTION
BEGINRELEASENOTES
- Use std::unique_ptr when possible in TrueJet_Parser to avoid manually managing the memory

ENDRELEASENOTES

Can you check if this works for you @nVentis? I don't have a recipe to do so. The `delall` then becomes not necessary but this will do exactly the same as it was doing before (if `deleteall` was being called before resetting the pointers).